### PR TITLE
Add AWS cognito authflow

### DIFF
--- a/api-gateway/src/main/kotlin/com/digitopia/gateway/config/GatewayConfig.kt
+++ b/api-gateway/src/main/kotlin/com/digitopia/gateway/config/GatewayConfig.kt
@@ -1,0 +1,53 @@
+package com.digitopia.gateway.config
+
+import com.digitopia.gateway.filter.JwtAuthenticationFilter
+import org.springframework.cloud.gateway.route.RouteLocator
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+
+@Configuration
+class GatewayConfig(private val jwtAuthFilter: JwtAuthenticationFilter) {
+
+    @Bean
+    fun routeLocator(builder: RouteLocatorBuilder): RouteLocator {
+        return builder.routes()
+            // Public routes
+            .route("auth-service") {
+                it.path("/api/v1/auth/**")
+                    .uri("lb://auth-service")
+            }
+            .route("health-check") {
+                it.path("/healtz")
+                    .uri("lb://api-gateway")
+            }
+            
+            // Protected routes with role-based access
+            .route("user-service") {
+                it.path("/api/v1/users/**")
+                    .and()
+                    .method(HttpMethod.DELETE)
+                    .and()
+                    .header("X-User-Role", "ADMIN")
+                    .filters(jwtAuthFilter.apply(JwtAuthenticationFilter.Config()))
+                    .uri("lb://user-service")
+            }
+            .route("user-service-manager") {
+                it.path("/api/v1/users/create")
+                    .and()
+                    .method(HttpMethod.POST)
+                    .and()
+                    .header("X-User-Role", listOf("ADMIN", "MANAGER"))
+                    .filters(jwtAuthFilter.apply(JwtAuthenticationFilter.Config()))
+                    .uri("lb://user-service")
+            }
+            .route("user-service-basic") {
+                it.path("/api/v1/users/**")
+                    .filters(jwtAuthFilter.apply(JwtAuthenticationFilter.Config()))
+                    .uri("lb://user-service")
+            }
+            // Add similar routes for organization and invitation services
+            .build()
+    }
+}

--- a/api-gateway/src/main/kotlin/com/digitopia/gateway/filter/JwtAuthenticationFilter.kt
+++ b/api-gateway/src/main/kotlin/com/digitopia/gateway/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,42 @@
+package com.digitopia.gateway.filter
+
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor
+import org.springframework.cloud.gateway.filter.GatewayFilter
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtProcessor: ConfigurableJWTProcessor<SecurityContext>
+) : AbstractGatewayFilterFactory<JwtAuthenticationFilter.Config>(Config::class.java) {
+
+    override fun apply(config: Config): GatewayFilter {
+        return GatewayFilter { exchange, chain ->
+            val token = exchange.request.headers["Authorization"]?.firstOrNull()?.removePrefix("Bearer ")
+                ?: return@GatewayFilter Mono.error(UnauthorizedException("No token provided"))
+
+            try {
+                val claims = jwtProcessor.process(token, null)
+                val role = claims.getClaim("custom:role") as? String
+                    ?: return@GatewayFilter Mono.error(UnauthorizedException("No role found in token"))
+
+                // Add claims to request headers for downstream services
+                val request = exchange.request.mutate()
+                    .header("X-User-Id", claims.subject)
+                    .header("X-User-Role", role)
+                    .build()
+
+                chain.filter(exchange.mutate().request(request).build())
+            } catch (e: Exception) {
+                Mono.error(UnauthorizedException("Invalid token"))
+            }
+        }
+    }
+
+    class Config
+}
+
+class UnauthorizedException(message: String) : RuntimeException(message)

--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+    kotlin("jvm")
+    kotlin("plugin.spring")
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("com.amazonaws:aws-java-sdk-cognitoidp:1.12.261")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
+}

--- a/auth-service/src/main/kotlin/com/digitopia/auth/AuthServiceApplication.kt
+++ b/auth-service/src/main/kotlin/com/digitopia/auth/AuthServiceApplication.kt
@@ -1,0 +1,11 @@
+package com.digitopia.auth
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class AuthServiceApplication
+
+fun main(args: Array<String>) {
+    runApplication<AuthServiceApplication>(*args)
+}

--- a/auth-service/src/main/kotlin/com/digitopia/auth/config/CognitoConfig.kt
+++ b/auth-service/src/main/kotlin/com/digitopia/auth/config/CognitoConfig.kt
@@ -1,0 +1,40 @@
+package com.digitopia.auth.config
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProviderClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CognitoConfig {
+    @Value("\${aws.cognito.region}")
+    private lateinit var region: String
+
+    @Value("\${aws.cognito.userPoolId}")
+    private lateinit var userPoolId: String
+
+    @Value("\${aws.cognito.clientId}")
+    private lateinit var clientId: String
+
+    @Value("\${aws.cognito.clientSecret}")
+    private lateinit var clientSecret: String
+
+    @Value("\${aws.cognito.jwk}")
+    private lateinit var jwkUrl: String
+
+    @Bean
+    fun cognitoClient(): AWSCognitoIdentityProvider {
+        return AWSCognitoIdentityProviderClientBuilder.standard()
+            .withRegion(region)
+            .build()
+    }
+
+    // Required getters for other components
+    fun getUserPoolId() = userPoolId
+    fun getClientId() = clientId
+    fun getClientSecret() = clientSecret
+    fun getJwkUrl() = jwkUrl
+}

--- a/auth-service/src/main/kotlin/com/digitopia/auth/controller/AuthController.kt
+++ b/auth-service/src/main/kotlin/com/digitopia/auth/controller/AuthController.kt
@@ -1,0 +1,28 @@
+package com.digitopia.auth.controller
+
+import com.digitopia.auth.model.AuthResponse
+import com.digitopia.auth.model.SignInRequest
+import com.digitopia.auth.model.SignUpRequest
+import com.digitopia.auth.service.AuthService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(private val authService: AuthService) {
+
+    @PostMapping("/signup")
+    fun signUp(@RequestBody request: SignUpRequest): ResponseEntity<Map<String, String>> {
+        val userId = authService.signUp(request)
+        return ResponseEntity.ok(mapOf("userId" to userId))
+    }
+
+    @PostMapping("/signin")
+    fun signIn(@RequestBody request: SignInRequest): ResponseEntity<AuthResponse> {
+        val response = authService.signIn(request)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/healtz")
+    fun healthCheck() = ResponseEntity.ok(mapOf("status" to "UP"))
+}

--- a/auth-service/src/main/kotlin/com/digitopia/auth/model/AuthModels.kt
+++ b/auth-service/src/main/kotlin/com/digitopia/auth/model/AuthModels.kt
@@ -1,0 +1,26 @@
+package com.digitopia.auth.model
+
+enum class Role {
+    ADMIN,
+    MANAGER,
+    USER
+}
+
+data class SignUpRequest(
+    val email: String,
+    val password: String,
+    val fullName: String,
+    val role: Role = Role.USER
+)
+
+data class SignInRequest(
+    val email: String,
+    val password: String
+)
+
+data class AuthResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Int,
+    val tokenType: String = "Bearer"
+)

--- a/auth-service/src/main/kotlin/com/digitopia/auth/service/AuthService.kt
+++ b/auth-service/src/main/kotlin/com/digitopia/auth/service/AuthService.kt
@@ -1,0 +1,80 @@
+package com.digitopia.auth.service
+
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider
+import com.amazonaws.services.cognitoidp.model.*
+import com.digitopia.auth.config.CognitoConfig
+import com.digitopia.auth.model.AuthResponse
+import com.digitopia.auth.model.Role
+import com.digitopia.auth.model.SignInRequest
+import com.digitopia.auth.model.SignUpRequest
+import org.springframework.stereotype.Service
+import java.util.*
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+@Service
+class AuthService(
+    private val cognitoClient: AWSCognitoIdentityProvider,
+    private val cognitoConfig: CognitoConfig
+) {
+    fun signUp(request: SignUpRequest): String {
+        val userAttributes = listOf(
+            AttributeType()
+                .withName("email")
+                .withValue(request.email),
+            AttributeType()
+                .withName("custom:full_name")
+                .withValue(request.fullName),
+            AttributeType()
+                .withName("custom:role")
+                .withValue(request.role.name)
+        )
+
+        val signUpRequest = SignUpRequest()
+            .withClientId(cognitoConfig.getClientId())
+            .withSecretHash(calculateSecretHash(request.email))
+            .withUsername(request.email)
+            .withPassword(request.password)
+            .withUserAttributes(userAttributes)
+
+        val result = cognitoClient.signUp(signUpRequest)
+        return result.userSub
+    }
+
+    fun signIn(request: SignInRequest): AuthResponse {
+        val authParams = mapOf(
+            "USERNAME" to request.email,
+            "PASSWORD" to request.password,
+            "SECRET_HASH" to calculateSecretHash(request.email)
+        )
+
+        val initiateAuthRequest = InitiateAuthRequest()
+            .withAuthFlow(AuthFlowType.USER_PASSWORD_AUTH)
+            .withClientId(cognitoConfig.getClientId())
+            .withAuthParameters(authParams)
+
+        val result = cognitoClient.initiateAuth(initiateAuthRequest)
+        val authResult = result.authenticationResult
+
+        return AuthResponse(
+            accessToken = authResult.accessToken,
+            refreshToken = authResult.refreshToken,
+            expiresIn = authResult.expiresIn
+        )
+    }
+
+    private fun calculateSecretHash(username: String): String {
+        val message = username + cognitoConfig.getClientId()
+        val secretKey = SecretKeySpec(
+            cognitoConfig.getClientSecret().toByteArray(StandardCharsets.UTF_8),
+            "HmacSHA256"
+        )
+        
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(secretKey)
+        val rawHmac = mac.doFinal(message.toByteArray(StandardCharsets.UTF_8))
+        return Base64.getEncoder().encodeToString(rawHmac)
+    }
+}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: auth-service
+
+aws:
+  cognito:
+    region: eu-west-1
+    userPoolId: ${AWS_COGNITO_USER_POOL_ID}
+    clientId: ${AWS_COGNITO_CLIENT_ID}
+    clientSecret: ${AWS_COGNITO_CLIENT_SECRET}
+    jwk: https://cognito-idp.${aws.cognito.region}.amazonaws.com/${aws.cognito.userPoolId}/.well-known/jwks.json


### PR DESCRIPTION
In order to use this:

- Configure AWS Cognito User Pool

- Set environment variables:

```
AWS_COGNITO_USER_POOL_ID
AWS_COGNITO_CLIENT_ID
AWS_COGNITO_CLIENT_SECRET
```

- Users can:

1. Register: POST /api/v1/auth/signup
2. Login: POST /api/v1/auth/signin
3. Use the returned JWT token in the Authorization header
4. Protected endpoints will automatically check roles and permissions based on the JWT token.